### PR TITLE
Fix missing module errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 numpy
 pandas
 matplotlib
-tensorflow==2.13.0
-tensorflow_probability
+tensorflow>=2.19.0
+tensorflow_probability[tf]
 jax
 scipy
 tqdm
@@ -11,4 +11,6 @@ sortedcontainers
 psutil
 numba
 blosc
-pywin32
+ipython
+tf-keras
+pywin32; platform_system=="Windows"


### PR DESCRIPTION
## Summary
- update python requirements to install ipython and tf-keras
- use a TensorFlow version compatible with newer Python
- make Windows-only dependency optional

## Testing
- `pip check`
- `python - <<'EOF'
from deephedging.trainer import train
print('import success')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684e97a08a688321b082479cd25def27