### PR TITLE
Add fallback for SortedDict & update TF version

### DIFF
--- a/cdxbasics/config.py
+++ b/cdxbasics/config.py
@@ -6,7 +6,7 @@ Hans Buehler 2022
 
 from collections import OrderedDict
 from collections.abc import Mapping
-from sortedcontainers import SortedDict
+from .sorted_dict import SortedDict
 from .util import uniqueHashExt, fmt_list
 from .prettydict import PrettyDict as pdct
 from .logger import Logger

--- a/cdxbasics/prettydict.py
+++ b/cdxbasics/prettydict.py
@@ -5,7 +5,7 @@ Hans Buehler 2022
 """
 
 from collections import OrderedDict
-from sortedcontainers import SortedDict
+from .sorted_dict import SortedDict
 from dataclasses import Field
 import types as types
 from collections.abc import Mapping, Collection

--- a/cdxbasics/sorted_dict.py
+++ b/cdxbasics/sorted_dict.py
@@ -1,0 +1,28 @@
+try:
+    from sortedcontainers import SortedDict
+except ModuleNotFoundError:  # pragma: no cover - fallback for environments without sortedcontainers
+    from collections import OrderedDict
+
+    class SortedDict(OrderedDict):
+        """Minimal fallback for :class:`sortedcontainers.SortedDict`.
+
+        Maintains keys in sorted order after insertions and updates.
+        Only implements the subset of the API used in this project."""
+
+        def __init__(self, *args, **kwargs):
+            super().__init__()
+            if args or kwargs:
+                self.update(*args, **kwargs)
+
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            self._reorder()
+
+        def update(self, *args, **kwargs):
+            super().update(*args, **kwargs)
+            self._reorder()
+
+        def _reorder(self):
+            items = sorted(super().items(), key=lambda kv: kv[0])
+            super().clear()
+            super().update(items)

--- a/cdxbasics/util.py
+++ b/cdxbasics/util.py
@@ -13,7 +13,7 @@ from collections.abc import Mapping, Collection, Sequence
 from .prettydict import PrettyDict, OrderedDict
 import sys as sys
 import time as time
-from sortedcontainers import SortedDict
+from .sorted_dict import SortedDict
 from collections.abc import Mapping, Collection
 
 # support for numpy and pandas is optional for this module

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy
 pandas
 matplotlib
-tensorflow==2.13.0
+tensorflow==2.18.0
 tensorflow_probability
 jax
 scipy


### PR DESCRIPTION
## Summary
- add fallback `SortedDict` implementation when `sortedcontainers` is missing
- update imports to use the new module
- bump TensorFlow to 2.18.0 for Python 3.12 support

## Testing
- `pip install --no-cache-dir tensorflow==2.18.0`
- `python - <<'PY'
import sys
sys.path.append('.')
from deephedging.trainer import train
print('trainer loaded')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_684e97a08a688321b082479cd25def27